### PR TITLE
fix: redact the root view of each fragment when redaction-by-default is active

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'com.google.gms:google-services:4.3.15'
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.0"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -73,4 +73,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'com.google.truth:truth:1.4.5'
 }

--- a/sample/src/androidTest/java/io/cobrowse/sample/ui/RedactionByDefaultDisappearingFragmentTest.kt
+++ b/sample/src/androidTest/java/io/cobrowse/sample/ui/RedactionByDefaultDisappearingFragmentTest.kt
@@ -1,0 +1,103 @@
+package io.cobrowse.sample.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import io.cobrowse.CobrowseIO
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RedactionByDefaultDisappearingFragmentTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val prefs get() = PreferenceManager.getDefaultSharedPreferences(context)
+
+    @Before
+    fun enableRedactionByDefault() {
+        prefs.edit().putBoolean("isRedactionByDefaultEnabled", true).commit()
+    }
+
+    @After
+    fun disableRedactionByDefault() {
+        prefs.edit().remove("isRedactionByDefaultEnabled").commit()
+    }
+
+    @Test
+    fun whenAccountFragmentIsDisappearing_collectRedactedViewsInFragments_includesItsRootView() {
+        ActivityScenario.launch(TestRedactionByDefaultActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.fragmentContainer
+                val accountFragment = TestAccountFragment()
+
+                activity.supportFragmentManager.beginTransaction()
+                    .add(container.id, accountFragment, "account")
+                    .commitNow()
+
+                val accountView = accountFragment.requireView()
+
+                assertThat(accountView.parent).isEqualTo(container)
+                assertThat(container.indexOfChild(accountView)).isNotEqualTo(-1)
+                assertThat(activity.collectRedactedViewsInFragments()).contains(accountView)
+
+                container.startViewTransition(accountView)
+                container.removeView(accountView)
+
+                try {
+                    assertThat(accountView.parent).isEqualTo(container)
+                    assertThat(container.indexOfChild(accountView)).isEqualTo(-1)
+
+                    assertThat(activity.collectRedactedViewsInFragments()).contains(accountView)
+                } finally {
+                    container.endViewTransition(accountView)
+                }
+            }
+        }
+    }
+}
+
+class TestAccountFragment : Fragment(), CobrowseIO.Redacted {
+
+    lateinit var accountEmail: TextView
+    lateinit var accountName: TextView
+    lateinit var logOut: Button
+    lateinit var privacyPolicy: Button
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = LinearLayout(requireContext()).apply {
+        orientation = LinearLayout.VERTICAL
+        accountName = TextView(requireContext()).also { addView(it) }
+        accountEmail = TextView(requireContext()).also { addView(it) }
+        logOut = Button(requireContext()).apply { text = "Log out" }.also { addView(it) }
+        privacyPolicy = Button(requireContext()).apply { text = "Privacy Policy" }
+            .also { addView(it) }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? ICobrowseRedactionContainer)?.notifyFragmentViewCreated(this)
+    }
+
+    override fun onDestroyView() {
+        (activity as? ICobrowseRedactionContainer)?.notifyFragmentViewDestroyed(this)
+        super.onDestroyView()
+    }
+
+    override fun redactedViews(): MutableList<View> =
+        mutableListOf(accountEmail, accountName)
+}

--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="io.cobrowse.sample.ui.TestRedactionByDefaultActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
+</manifest>

--- a/sample/src/debug/java/io/cobrowse/sample/ui/TestRedactionByDefaultActivity.kt
+++ b/sample/src/debug/java/io/cobrowse/sample/ui/TestRedactionByDefaultActivity.kt
@@ -1,0 +1,27 @@
+package io.cobrowse.sample.ui
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+
+@VisibleForTesting
+class TestRedactionByDefaultActivity : AppCompatActivity(),
+    ICobrowseRedactionContainer by CobrowseRedactionContainer() {
+
+    lateinit var fragmentContainer: FrameLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        fragmentContainer = FrameLayout(this).apply {
+            id = View.generateViewId()
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+        }
+        setContentView(fragmentContainer)
+    }
+}

--- a/sample/src/main/java/io/cobrowse/sample/ui/CobrowseRedactionContainer.kt
+++ b/sample/src/main/java/io/cobrowse/sample/ui/CobrowseRedactionContainer.kt
@@ -3,6 +3,7 @@ package io.cobrowse.sample.ui
 import android.view.View
 import androidx.fragment.app.Fragment
 import io.cobrowse.CobrowseIO
+import io.cobrowse.sample.data.CobrowseSessionDelegate
 
 /**
  * Helps track all fragments with active (alive) views in an activity, including fragments which are
@@ -42,6 +43,19 @@ class CobrowseRedactionContainer : ICobrowseRedactionContainer {
     }
 
     override fun collectRedactedViewsInFragments(): MutableList<View> {
+        if (this.fragmentsWithViews.let { it.isNotEmpty() && CobrowseSessionDelegate.isRedactionByDefaultEnabled(it.first().requireContext()) }) {
+            // At the exact moment when one fragment is replaced with another one,
+            // the views from the first fragment are getting replaced in the activity's view hierarchy
+            // by the views from the second fragment.
+            // The Cobrowse SDK cannot find the old views anymore,
+            // yet they are still briefly visible for a few milliseconds until
+            // the fragment transaction animation finishes.
+            // To prevent the sensitive data from being visible during this time,
+            // we treat all views from the fragments with redaction enabled as redacted.
+            return this.fragmentsWithViews
+                .flatMap { it.view?.let { v -> listOf<View>(v) } ?: emptyList<View>() }
+                .toMutableList()
+        }
         return this.fragmentsWithViews
                 .filter { it is CobrowseIO.Redacted }
                 .flatMap { (it as CobrowseIO.Redacted).redactedViews() as MutableList<View?> }

--- a/sample/src/main/java/io/cobrowse/sample/ui/CobrowseRedactionContainer.kt
+++ b/sample/src/main/java/io/cobrowse/sample/ui/CobrowseRedactionContainer.kt
@@ -43,22 +43,24 @@ class CobrowseRedactionContainer : ICobrowseRedactionContainer {
     }
 
     override fun collectRedactedViewsInFragments(): MutableList<View> {
-        if (this.fragmentsWithViews.let { it.isNotEmpty() && CobrowseSessionDelegate.isRedactionByDefaultEnabled(it.first().requireContext()) }) {
-            // At the exact moment when one fragment is replaced with another one,
-            // the views from the first fragment are getting replaced in the activity's view hierarchy
-            // by the views from the second fragment.
-            // The Cobrowse SDK cannot find the old views anymore,
-            // yet they are still briefly visible for a few milliseconds until
-            // the fragment transaction animation finishes.
-            // To prevent the sensitive data from being visible during this time,
-            // we treat all views from the fragments with redaction enabled as redacted.
-            return this.fragmentsWithViews
-                .flatMap { it.view?.let { v -> listOf<View>(v) } ?: emptyList<View>() }
-                .toMutableList()
-        }
         return this.fragmentsWithViews
-                .filter { it is CobrowseIO.Redacted }
-                .flatMap { (it as CobrowseIO.Redacted).redactedViews() as MutableList<View?> }
+                .flatMap {
+                    if (CobrowseSessionDelegate.isRedactionByDefaultEnabled(it.requireContext())) {
+                        // At the exact moment when one fragment is replaced with another one,
+                        // the views from the first fragment are getting replaced in the activity's view hierarchy
+                        // by the views from the second fragment.
+                        // The Cobrowse SDK cannot find the old views anymore,
+                        // yet they are still briefly visible for a few milliseconds until
+                        // the fragment transaction animation finishes.
+                        // To prevent the sensitive data from being visible during this time,
+                        // we treat all views from the fragments with redaction enabled as redacted.
+                        listOf<View?>(it.view)
+                    } else if (it is CobrowseIO.Redacted) {
+                        it.redactedViews() as List<View?>
+                    } else {
+                        emptyList<View?>()
+                    }
+                }
                 .filterNotNull()
                 .toMutableList()
     }


### PR DESCRIPTION
This is continuation of #13

Right when one fragment is replaced with another one, the views from the first fragment are getting replaced by the views from the second fragment in the activity’s view hierarchy. The Cobrowse SDK cannot find the old views anymore yet they are still getting briefly captured by the renderer.

We can explicitly remember roots of each fragment in the app and pass the roots into the SDK to be explicitly redacted.